### PR TITLE
Quote column names

### DIFF
--- a/lib/sqlite_magic.rb
+++ b/lib/sqlite_magic.rb
@@ -39,7 +39,7 @@ module SqliteMagic
                             "CREATE TABLE #{tbl_name} (#{format_field_names_as_string(col_names)})"
       database.execute query
       if unique_keys && !unique_keys.empty?
-        query = "CREATE UNIQUE INDEX IF NOT EXISTS #{unique_keys.join('_')} " +
+        query = "CREATE UNIQUE INDEX IF NOT EXISTS '#{unique_keys.join('_')}' " +
           "ON #{tbl_name} (#{format_field_names_as_string(unique_keys)})"
         database.execute query
       end

--- a/lib/sqlite_magic.rb
+++ b/lib/sqlite_magic.rb
@@ -64,13 +64,13 @@ module SqliteMagic
     def insert_or_update(uniq_keys, values_hash, tbl_name='main_table', opts={})
       all_field_names = values_hash.keys
       field_names_as_symbol_string = all_field_names.map{ |k| ":#{k}" }.join(',') # need to appear as symbols
-      sql_statement = "INSERT INTO #{tbl_name} (#{all_field_names.join(',')}) VALUES (#{field_names_as_symbol_string})"
+      sql_statement = "INSERT INTO #{tbl_name} (#{all_field_names.map{ |k| "'#{k}'" }.join(',')}) VALUES (#{field_names_as_symbol_string})"
       database.execute(sql_statement, values_hash)
     rescue SQLite3::ConstraintException => e
-      unique_key_constraint = uniq_keys.map { |k| "#{k}=:#{k}" }.join(' AND ')
+      unique_key_constraint = uniq_keys.map { |k| "'#{k}'=:#{k}" }.join(' AND ')
       update_keys = values_hash.keys
       update_keys -= uniq_keys if !opts[:update_unique_keys]
-      update_sql = update_keys.map { |k| "#{k}=:#{k}" }.join(', ')
+      update_sql = update_keys.map { |k| "'#{k}'=:#{k}" }.join(', ')
       sql_statement = "UPDATE #{tbl_name} SET #{update_sql} WHERE #{unique_key_constraint}"
       database.execute sql_statement, values_hash
     rescue SQLite3::SQLException => e

--- a/lib/sqlite_magic.rb
+++ b/lib/sqlite_magic.rb
@@ -35,12 +35,12 @@ module SqliteMagic
 
     def create_table(tbl_name, col_names, unique_keys=nil)
       puts "Now creating new table: #{tbl_name}" if verbose?
-      query = unique_keys ? "CREATE TABLE #{tbl_name} (#{col_names.join(',')}, UNIQUE (#{unique_keys.join(',')}))" :
-                            "CREATE TABLE #{tbl_name} (#{col_names.join(',')})"
+      query = unique_keys ? "CREATE TABLE #{tbl_name} (#{col_names.map{ |k| "'#{k}'" }.join(',')}, UNIQUE (#{unique_keys.map{ |k| "'#{k}'" }.join(',')}))" :
+                            "CREATE TABLE #{tbl_name} (#{col_names.map{ |k| "'#{k}'" }.join(',')})"
       database.execute query
       if unique_keys && !unique_keys.empty?
         query = "CREATE UNIQUE INDEX IF NOT EXISTS #{unique_keys.join('_')} " +
-          "ON #{tbl_name} (#{unique_keys.join(',')})"
+          "ON #{tbl_name} (#{unique_keys.map{ |k| "'#{k}'" }.join(',')})"
         database.execute query
       end
     end
@@ -91,7 +91,7 @@ module SqliteMagic
     def save_data(uniq_keys, values_array, tbl_name)
       values_array = [values_array].flatten(1) # coerce to an array
       all_field_names = values_array.map(&:keys).flatten.uniq
-      all_field_names_as_string = all_field_names.join(',')
+      all_field_names_as_string = all_field_names.map{ |k| "'#{k}'" }.join(',')
       all_field_names_as_symbol_string = all_field_names.map{ |k| ":#{k}" }.join(',') # need to appear as symbols
       begin
         values_array.each do |values_hash|

--- a/lib/sqlite_magic.rb
+++ b/lib/sqlite_magic.rb
@@ -21,7 +21,7 @@ module SqliteMagic
       existing_cols = database.table_info(tbl_name).map{ |c| c['name'] }
       missing_cols = col_names.map(&:to_s) - existing_cols
       missing_cols.each do |col_name|
-        database.execute("ALTER TABLE #{tbl_name} ADD COLUMN #{col_name}")
+        database.execute("ALTER TABLE #{tbl_name} ADD COLUMN '#{col_name}'")
       end
     end
 

--- a/spec/lib/sqlite_magic_spec.rb
+++ b/spec/lib/sqlite_magic_spec.rb
@@ -130,8 +130,8 @@ describe SqliteMagic do
         @data = [{:foo => 'bar', :foo2 => 'bar2', :foo3 => 'bar3'},
                  {:foo2 => 'baz2', :foo3 => 'baz3', :foo4 => 'baz4'}]
         @unique_keys = [:foo2,:foo3]
-        @expected_query_1 = "INSERT OR REPLACE INTO foo_table (foo,foo2,foo3,foo4) VALUES (:foo,:foo2,:foo3,:foo4)"
-        @expected_query_2 = "INSERT OR REPLACE INTO foo_table (foo,foo2,foo3,foo4) VALUES (:foo,:foo2,:foo3,:foo4)"
+        @expected_query_1 = "INSERT OR REPLACE INTO foo_table ('foo','foo2','foo3','foo4') VALUES (:foo,:foo2,:foo3,:foo4)"
+        @expected_query_2 = "INSERT OR REPLACE INTO foo_table ('foo','foo2','foo3','foo4') VALUES (:foo,:foo2,:foo3,:foo4)"
       end
 
       it 'should insert each data hash using all given field names' do
@@ -143,7 +143,7 @@ describe SqliteMagic do
 
       context 'and datum is a single hash' do
         it 'should save the hash' do
-          @expected_query_1 = "INSERT OR REPLACE INTO foo_table (foo,foo2,foo3) VALUES (:foo,:foo2,:foo3)"
+          @expected_query_1 = "INSERT OR REPLACE INTO foo_table ('foo','foo2','foo3') VALUES (:foo,:foo2,:foo3)"
           @dummy_db.should_receive(:execute).with(@expected_query_1, @data.first)
           @connection.save_data(@unique_keys, @data.first, 'foo_table')
         end
@@ -215,15 +215,15 @@ describe SqliteMagic do
 
     describe '#create_table' do
       it 'should create default table using given field names' do
-        expected_query = "CREATE TABLE some_table (foo,bar,baz)"
+        expected_query = "CREATE TABLE some_table ('foo','bar','baz')"
         @dummy_db.should_receive(:execute).with(expected_query)
         @connection.create_table(:some_table, [:foo,:bar,:baz])
       end
 
       context 'and unique keys are given' do
         it 'should add constraint and index for given keys' do
-          expected_query_1 = "CREATE TABLE some_table (foo,bar,baz, UNIQUE (foo,baz))"
-          expected_query_2 = "CREATE UNIQUE INDEX IF NOT EXISTS foo_baz ON some_table (foo,baz)"
+          expected_query_1 = "CREATE TABLE some_table ('foo','bar','baz', UNIQUE ('foo','baz'))"
+          expected_query_2 = "CREATE UNIQUE INDEX IF NOT EXISTS foo_baz ON some_table ('foo','baz')"
           @dummy_db.should_receive(:execute).with(expected_query_1)
           @dummy_db.should_receive(:execute).with(expected_query_2)
           @connection.create_table(:some_table, [:foo,:bar,:baz], [:foo,:baz])

--- a/spec/lib/sqlite_magic_spec.rb
+++ b/spec/lib/sqlite_magic_spec.rb
@@ -255,7 +255,7 @@ describe SqliteMagic do
       before do
         @datum = {:foo => 'bar', :foo2 => 'bar2', :foo3 => 'bar3', :foo4 => 'bar4'}
         @unique_keys = [:foo2,:foo3]
-        @expected_query = "INSERT INTO foo_table (foo,foo2,foo3,foo4) VALUES (:foo,:foo2,:foo3,:foo4)"
+        @expected_query = "INSERT INTO foo_table ('foo','foo2','foo3','foo4') VALUES (:foo,:foo2,:foo3,:foo4)"
       end
 
       it 'should insert data' do
@@ -270,7 +270,7 @@ describe SqliteMagic do
 
       context 'and no table name given' do
         before do
-          @expected_query = "INSERT INTO main_table (foo,foo2,foo3,foo4) VALUES (:foo,:foo2,:foo3,:foo4)"
+          @expected_query = "INSERT INTO main_table ('foo','foo2','foo3','foo4') VALUES (:foo,:foo2,:foo3,:foo4)"
         end
 
         it 'should use main_table table by default' do
@@ -282,7 +282,7 @@ describe SqliteMagic do
       context 'and data already exists' do
         before do
           @dummy_db.stub(:execute).with(/INSERT/, anything).and_raise(SQLite3::ConstraintException.new('constraint failed'))
-          @expected_update_query = "UPDATE foo_table SET foo=:foo, foo4=:foo4 WHERE foo2=:foo2 AND foo3=:foo3"
+          @expected_update_query = "UPDATE foo_table SET 'foo'=:foo, 'foo4'=:foo4 WHERE 'foo2'=:foo2 AND 'foo3'=:foo3"
         end
 
         it 'should update given columns dependent on unique keys' do
@@ -292,7 +292,7 @@ describe SqliteMagic do
 
         context "and :update_unique_keys specified in opts" do
           it 'should update all columns including unique keys' do
-            @expected_update_query = "UPDATE foo_table SET foo=:foo, foo2=:foo2, foo3=:foo3, foo4=:foo4 WHERE foo2=:foo2 AND foo3=:foo3"
+            @expected_update_query = "UPDATE foo_table SET 'foo'=:foo, 'foo2'=:foo2, 'foo3'=:foo3, 'foo4'=:foo4 WHERE 'foo2'=:foo2 AND 'foo3'=:foo3"
             @dummy_db.should_receive(:execute).with(@expected_update_query, @datum)
             @connection.insert_or_update(@unique_keys, @datum, 'foo_table', :update_unique_keys => true)
           end
@@ -300,7 +300,7 @@ describe SqliteMagic do
 
         context 'and no table name given' do
           before do
-            @expected_update_query = "UPDATE main_table SET foo=:foo, foo4=:foo4 WHERE foo2=:foo2 AND foo3=:foo3"
+            @expected_update_query = "UPDATE main_table SET 'foo'=:foo, 'foo4'=:foo4 WHERE 'foo2'=:foo2 AND 'foo3'=:foo3"
           end
 
           it 'should use main_table table by default' do
@@ -313,7 +313,7 @@ describe SqliteMagic do
           before do
             @dummy_db.should_receive(:execute).with(@expected_query, @datum).
                       and_raise(SQLite3::SQLException.new("table mynewtable has no column named foo") )
-            @expected_update_query = "UPDATE foo_table SET foo=:foo, foo4=:foo4 WHERE foo2=:foo2 AND foo3=:foo3"
+            @expected_update_query = "UPDATE foo_table SET 'foo'=:foo, 'foo4'=:foo4 WHERE 'foo2'=:foo2 AND 'foo3'=:foo3"
           end
 
           it 'should create missing fields using all field names and unique keys' do

--- a/spec/lib/sqlite_magic_spec.rb
+++ b/spec/lib/sqlite_magic_spec.rb
@@ -245,8 +245,8 @@ describe SqliteMagic do
 
       it 'should add columns that arent there already' do
         @dummy_db.stub(:table_info).and_return(@table_info)
-        @dummy_db.should_receive(:execute).with('ALTER TABLE foo_table ADD COLUMN foo')
-        @dummy_db.should_receive(:execute).with('ALTER TABLE foo_table ADD COLUMN baz')
+        @dummy_db.should_receive(:execute).with("ALTER TABLE foo_table ADD COLUMN 'foo'")
+        @dummy_db.should_receive(:execute).with("ALTER TABLE foo_table ADD COLUMN 'baz'")
         @connection.add_columns(:foo_table, [:foo,:bar,:baz])
       end
     end

--- a/spec/lib/sqlite_magic_spec.rb
+++ b/spec/lib/sqlite_magic_spec.rb
@@ -223,7 +223,7 @@ describe SqliteMagic do
       context 'and unique keys are given' do
         it 'should add constraint and index for given keys' do
           expected_query_1 = "CREATE TABLE some_table ('foo','bar','baz', UNIQUE ('foo','baz'))"
-          expected_query_2 = "CREATE UNIQUE INDEX IF NOT EXISTS foo_baz ON some_table ('foo','baz')"
+          expected_query_2 = "CREATE UNIQUE INDEX IF NOT EXISTS 'foo_baz' ON some_table ('foo','baz')"
           @dummy_db.should_receive(:execute).with(expected_query_1)
           @dummy_db.should_receive(:execute).with(expected_query_2)
           @connection.create_table(:some_table, [:foo,:bar,:baz], [:foo,:baz])


### PR DESCRIPTION
This allows columns names that use SQL keywords such as "group".

It means this works OK:

``` ruby
c = SqliteMagic::Connection.new("test.sqlite")
c.save_data(["group"], {"group" => "foobar"}, "data")
```
